### PR TITLE
Add foundational Windows validation and security tooling

### DIFF
--- a/docs/windows_tooling.md
+++ b/docs/windows_tooling.md
@@ -1,0 +1,358 @@
+# Windows Tooling Summary
+
+This repo now has a Windows-first validation and security-smoke toolchain under `tools/windows/`.
+
+## Core helper
+
+### `common.ps1`
+
+Shared infrastructure used by every other script.
+
+It handles:
+
+- Repo-root detection from `tools/windows/`
+- npm-only package-manager enforcement via `package-lock.json`
+- Required command checks
+- `node_modules` / local npm binary checks
+- Command logging with exact command lines
+- `Push-Location` / `Pop-Location` so scripts return you to your original directory
+- Native exit-code preservation
+- Readable final failure blocks
+- Optional `-PauseOnFailure` support
+- Safe repo-relative path checks for scanner-style scripts
+
+This is the foundation that makes the other scripts behave consistently.
+
+## Basic workflow scripts
+
+### `setup.ps1`
+
+Purpose: prepare/check the repo on Windows.
+
+Runs:
+
+```powershell
+node -v
+npm.cmd -v
+npm.cmd ci
+```
+
+Options:
+
+```powershell
+.\tools\windows\setup.ps1
+.\tools\windows\setup.ps1 -SkipInstall
+.\tools\windows\setup.ps1 -PauseOnFailure
+```
+
+Current expected result: **passes**, but `npm ci` reports existing dependency warnings and audit vulnerabilities.
+
+---
+
+### `test.ps1`
+
+Purpose: run the normal Vitest test suite.
+
+Runs:
+
+```powershell
+npm.cmd run test
+```
+
+Options:
+
+```powershell
+.\tools\windows\test.ps1
+.\tools\windows\test.ps1 -TestFilter "pow"
+.\tools\windows\test.ps1 -Watch
+.\tools\windows\test.ps1 -PauseOnFailure
+```
+
+Current expected result: **passes**. Reported result: **19 files / 299 tests**.
+
+---
+
+### `typecheck.ps1`
+
+Purpose: run the strict TypeScript/Vue typecheck gate.
+
+Runs:
+
+```powershell
+npm.cmd exec -- vue-tsc --noEmit -p tsconfig.json
+```
+
+Options:
+
+```powershell
+.\tools\windows\typecheck.ps1
+.\tools\windows\typecheck.ps1 -PauseOnFailure
+```
+
+Current expected result: **fails** with existing repo errors.
+
+---
+
+### `security-audit.ps1`
+
+Purpose: run `npm audit` as a dependency security gate.
+
+Runs by default:
+
+```powershell
+npm.cmd audit --audit-level=high
+```
+
+Options:
+
+```powershell
+.\tools\windows\security-audit.ps1
+.\tools\windows\security-audit.ps1 -AuditLevel moderate
+.\tools\windows\security-audit.ps1 -AuditLevel critical
+.\tools\windows\security-audit.ps1 -ProductionOnly
+.\tools\windows\security-audit.ps1 -Json
+.\tools\windows\security-audit.ps1 -PauseOnFailure
+```
+
+Current expected result: **fails** because the repo currently has real npm audit findings.
+
+---
+
+### `validate.ps1`
+
+Purpose: one Windows PR-validation entrypoint.
+
+Runs in order:
+
+1. `typecheck.ps1`
+2. `test.ps1`
+3. `security-audit.ps1`
+4. `npm run build`
+
+Options:
+
+```powershell
+.\tools\windows\validate.ps1
+.\tools\windows\validate.ps1 -SkipAudit
+.\tools\windows\validate.ps1 -SkipBuild
+.\tools\windows\validate.ps1 -TestFilter "pow"
+.\tools\windows\validate.ps1 -PauseOnFailure
+```
+
+Current expected result: **fails closed at typecheck** before tests, audit, or build. That is correct because `typecheck.ps1` currently fails.
+
+## Security/adversarial scripts
+
+### `adversarial-test.ps1`
+
+Purpose: run a focused security/adversarial Vitest subset without starting live services.
+
+Default test filters:
+
+```text
+ws-validators.test.js
+pow-challenge.test.js
+security-utils.test.js
+rate-limiter.test.js
+bot-detector.test.js
+spam-scorer.test.js
+chainValidation.test.ts
+eventService.test.ts
+cryptoService.test.ts
+config.test.ts
+mnemonicHelper.test.ts
+```
+
+Options:
+
+```powershell
+.\tools\windows\adversarial-test.ps1
+.\tools\windows\adversarial-test.ps1 -TestFilter "pow-challenge.test.js"
+.\tools\windows\adversarial-test.ps1 -PauseOnFailure
+```
+
+Current expected result: **passes**. Reported result: **11 files / 213 tests**.
+
+This is the “try to break protocol/security-relevant unit coverage” lane.
+
+---
+
+### `secret-scan.ps1`
+
+Purpose: scan tracked text files for high-confidence hard-coded secrets without adding dependencies.
+
+It scans `git ls-files`, skips generated/runtime/binary-ish paths, and looks for patterns like:
+
+- Private key blocks
+- Generic `api_key` / `secret` / `token` / `password` assignments
+- Bearer tokens
+- Google API keys
+- GitHub tokens
+- Slack tokens
+- AWS access keys
+- Possible JWTs
+
+Options:
+
+```powershell
+.\tools\windows\secret-scan.ps1
+.\tools\windows\secret-scan.ps1 -FailOnFinding
+.\tools\windows\secret-scan.ps1 -IncludeDocs
+.\tools\windows\secret-scan.ps1 -PauseOnFailure
+```
+
+Default behavior: scans tracked files only, **report-only**, exit `0`.
+
+Current expected result: **passes with no high-confidence secrets found**.
+
+---
+
+### `security-smoke.ps1`
+
+Purpose: aggregate the local security checks and keep going so you get a useful summary.
+
+Runs:
+
+1. `adversarial-test.ps1`
+2. `secret-scan.ps1`
+3. `security-audit.ps1`
+
+Options:
+
+```powershell
+.\tools\windows\security-smoke.ps1
+.\tools\windows\security-smoke.ps1 -SkipAudit
+.\tools\windows\security-smoke.ps1 -SkipAdversarialTests
+.\tools\windows\security-smoke.ps1 -SkipSecretScan
+.\tools\windows\security-smoke.ps1 -AuditLevel critical
+.\tools\windows\security-smoke.ps1 -ProductionOnly
+.\tools\windows\security-smoke.ps1 -FailOnSecretFinding
+.\tools\windows\security-smoke.ps1 -AllowNoChecks
+.\tools\windows\security-smoke.ps1 -PauseOnFailure
+```
+
+Current expected result:
+
+```text
+adversarial tests: pass
+secret scan: pass
+dependency audit: fail
+overall: fail with exit 1
+```
+
+And:
+
+```powershell
+.\tools\windows\security-smoke.ps1 -SkipAudit
+```
+
+should pass cleanly.
+
+## What this gives you practically
+
+You now have:
+
+```text
+setup.ps1              dependency install / Windows setup
+test.ps1               normal unit test gate
+typecheck.ps1          strict TS/Vue correctness gate
+security-audit.ps1     npm dependency vulnerability gate
+validate.ps1           PR-style validation gate
+adversarial-test.ps1   focused protocol/security unit-test lane
+secret-scan.ps1        local hard-coded secret scanner
+security-smoke.ps1     combined local security smoke lane
+common.ps1             shared script infrastructure
+```
+
+The repo’s current health is:
+
+```text
+Setup: passes
+Tests: pass
+Adversarial tests: pass
+Secret scan: pass
+Typecheck: fails on existing TS/Vue errors
+Dependency audit: fails on existing vulnerabilities
+Validate: fails at typecheck
+Security smoke: fails at dependency audit
+Security smoke -SkipAudit: passes
+```
+
+## Call Tree
+
+```text
+common.ps1
+├─ shared by all scripts
+│
+├─ setup.ps1
+│  ├─ node -v
+│  ├─ npm.cmd -v
+│  └─ npm.cmd ci
+│
+├─ test.ps1
+│  └─ npm.cmd run test [-- filters]
+│
+├─ typecheck.ps1
+│  └─ npm.cmd exec -- vue-tsc --noEmit -p tsconfig.json
+│
+├─ security-audit.ps1
+│  └─ npm.cmd audit --audit-level=<moderate|high|critical>
+│
+├─ secret-scan.ps1
+│  ├─ git ls-files -z
+│  └─ PowerShell regex scan over tracked text files
+│
+├─ validate.ps1
+│  ├─ typecheck.ps1
+│  │  └─ npm.cmd exec -- vue-tsc --noEmit -p tsconfig.json
+│  ├─ test.ps1
+│  │  └─ npm.cmd run test [-- filters]
+│  ├─ security-audit.ps1
+│  │  └─ npm.cmd audit --audit-level=high
+│  └─ npm.cmd run build
+│
+├─ adversarial-test.ps1
+│  └─ test.ps1 -TestFilter <security/adversarial filters>
+│     └─ npm.cmd run test -- <filters>
+│
+└─ security-smoke.ps1
+   ├─ adversarial-test.ps1
+   │  └─ test.ps1 -TestFilter <security/adversarial filters>
+   │     └─ npm.cmd run test -- <filters>
+   ├─ secret-scan.ps1
+   │  ├─ git ls-files -z
+   │  └─ regex scan
+   └─ security-audit.ps1
+      └─ npm.cmd audit --audit-level=high
+```
+
+## Details
+
+```text
+setup.ps1
+  Get the repo ready.
+
+test.ps1
+  Do normal tests pass?
+
+typecheck.ps1
+  Is the TypeScript/Vue code type-correct?
+
+security-audit.ps1
+  Are npm dependencies free of high+ advisories?
+
+validate.ps1
+  Run the main PR gate.
+
+adversarial-test.ps1
+  Run security/protocol-focused tests.
+
+secret-scan.ps1
+  Look for hard-coded secrets.
+
+security-smoke.ps1
+  Run the local security lane and summarize everything.
+
+common.ps1
+  Shared infrastructure that makes all of the above consistent.
+```

--- a/tools/windows/adversarial-test.ps1
+++ b/tools/windows/adversarial-test.ps1
@@ -1,0 +1,62 @@
+# Run the focused local adversarial/security Vitest subset on Windows.
+
+[CmdletBinding()]
+param(
+  [string[]]$TestFilter = @(),
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+$defaultFilters = @(
+  'ws-validators.test.js',
+  'pow-challenge.test.js',
+  'security-utils.test.js',
+  'rate-limiter.test.js',
+  'bot-detector.test.js',
+  'spam-scorer.test.js',
+  'chainValidation.test.ts',
+  'eventService.test.ts',
+  'cryptoService.test.ts',
+  'config.test.ts',
+  'mnemonicHelper.test.ts'
+)
+
+function ConvertTo-PowerShellSingleQuotedLiteral {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value
+  )
+
+  return "'" + ($Value -replace "'", "''") + "'"
+}
+
+try {
+  $repoRoot = Resolve-RepoRoot
+  $filters = if ($TestFilter.Count -gt 0) { $TestFilter } else { $defaultFilters }
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    Get-NpmCommand | Out-Null
+    Assert-NodeModulesInstalled -RepoRoot $repoRoot
+    Assert-LocalNpmBin -Name 'vitest' -RepoRoot $repoRoot | Out-Null
+  }
+
+  Write-Host 'Running focused adversarial/security tests:'
+  foreach ($filter in $filters) {
+    Write-Host "  - $filter"
+  }
+
+  $testScriptPath = Join-Path $PSScriptRoot 'test.ps1'
+  $filterLiteral = '@(' + (($filters | ForEach-Object {
+    ConvertTo-PowerShellSingleQuotedLiteral -Value $_
+  }) -join ', ') + ')'
+  $command = '& ' + (ConvertTo-PowerShellSingleQuotedLiteral -Value $testScriptPath) + " -TestFilter $filterLiteral"
+  $powerShell = Get-PowerShellExecutable
+  Invoke-LoggedCommand -FilePath $powerShell -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', $command)
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Adversarial tests failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/common.ps1
+++ b/tools/windows/common.ps1
@@ -1,0 +1,365 @@
+# Shared helpers for Windows contributor scripts.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$global:InterPollLastCommandExitCode = 0
+
+function Resolve-RepoRoot {
+  [CmdletBinding()]
+  param()
+
+  $root = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')
+  $rootPath = $root.ProviderPath
+  $packageJson = Join-Path $rootPath 'package.json'
+
+  if (-not (Test-Path -LiteralPath $packageJson -PathType Leaf)) {
+    throw "Could not resolve repo root from '$PSScriptRoot'. Missing package.json at '$packageJson'."
+  }
+
+  return $rootPath
+}
+
+function Get-PackageManager {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Resolve-RepoRoot)
+  )
+
+  $packageLock = Join-Path $RepoRoot 'package-lock.json'
+  if (-not (Test-Path -LiteralPath $packageLock -PathType Leaf)) {
+    throw 'This repo expects npm, but package-lock.json was not found.'
+  }
+
+  $unexpectedLockFiles = @(
+    'pnpm-lock.yaml',
+    'yarn.lock',
+    'bun.lock',
+    'bun.lockb',
+    'npm-shrinkwrap.json'
+  )
+
+  $presentUnexpected = @(
+    foreach ($lockFile in $unexpectedLockFiles) {
+      if (Test-Path -LiteralPath (Join-Path $RepoRoot $lockFile) -PathType Leaf) {
+        $lockFile
+      }
+    }
+  )
+
+  if ($presentUnexpected.Count -gt 0) {
+    throw "Ambiguous package manager lockfiles found: $($presentUnexpected -join ', '). This script only supports npm for this repo."
+  }
+
+  $packageJsonPath = Join-Path $RepoRoot 'package.json'
+  $packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+  $hasPackageManager = $packageJson.PSObject.Properties.Name -contains 'packageManager'
+
+  if ($hasPackageManager -and $packageJson.packageManager -and ($packageJson.packageManager -notmatch '^npm@')) {
+    throw "package.json declares packageManager '$($packageJson.packageManager)', but package-lock.json indicates npm."
+  }
+
+  return 'npm'
+}
+
+function Assert-CommandAvailable {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $command) {
+    throw "Required command '$Name' was not found on PATH."
+  }
+
+  return $command
+}
+
+function Get-NpmCommand {
+  [CmdletBinding()]
+  param()
+
+  $npmCmd = Get-Command 'npm.cmd' -ErrorAction SilentlyContinue
+  if ($npmCmd) {
+    return 'npm.cmd'
+  }
+
+  Assert-CommandAvailable -Name 'npm' | Out-Null
+  return 'npm'
+}
+
+function Assert-NodeModulesInstalled {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Resolve-RepoRoot)
+  )
+
+  if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot 'node_modules') -PathType Container)) {
+    throw "node_modules is missing. Run '.\tools\windows\setup.ps1' first."
+  }
+}
+
+function Assert-LocalNpmBin {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [string]$RepoRoot = (Resolve-RepoRoot)
+  )
+
+  $binDir = Join-Path $RepoRoot 'node_modules\.bin'
+  $candidates = @(
+    (Join-Path $binDir "$Name.cmd"),
+    (Join-Path $binDir "$Name.ps1"),
+    (Join-Path $binDir $Name)
+  )
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return $candidate
+    }
+  }
+
+  throw "Local npm binary '$Name' was not found under node_modules\.bin. Run '.\tools\windows\setup.ps1' first."
+}
+
+function Format-CommandLine {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  $parts = @($FilePath) + $ArgumentList
+  return (($parts | ForEach-Object {
+    $part = [string]$_
+    if ($part.Length -eq 0) {
+      '""'
+    } elseif ($part -match '[\s"]') {
+      '"' + ($part -replace '"', '\"') + '"'
+    } else {
+      $part
+    }
+  }) -join ' ')
+}
+
+function New-CommandFailedException {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+
+    [Parameter(Mandatory = $true)]
+    [int]$ExitCode,
+
+    [string]$CommandLine = ''
+  )
+
+  $exception = [System.Exception]::new($Message)
+  $exception.Data['ExitCode'] = $ExitCode
+  if ($CommandLine) {
+    $exception.Data['CommandLine'] = $CommandLine
+  }
+  return $exception
+}
+
+function Invoke-LoggedCommand {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  $commandLine = Format-CommandLine -FilePath $FilePath -ArgumentList $ArgumentList
+  Write-Host ">> $commandLine"
+
+  $global:InterPollLastCommandExitCode = 0
+  & $FilePath @ArgumentList
+  $exitCode = if ($LASTEXITCODE -is [int]) { [int]$LASTEXITCODE } else { 0 }
+
+  if ($exitCode -ne 0) {
+    $global:InterPollLastCommandExitCode = $exitCode
+    throw (New-CommandFailedException -Message "Command failed with exit code ${exitCode}: $commandLine" -ExitCode $exitCode -CommandLine $commandLine)
+  }
+}
+
+function Invoke-InRepo {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$ScriptBlock
+  )
+
+  Push-Location -LiteralPath $RepoRoot
+  try {
+    & $ScriptBlock
+  } finally {
+    Pop-Location
+  }
+}
+
+function Get-PowerShellExecutable {
+  [CmdletBinding()]
+  param()
+
+  $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+  if ($pwsh) {
+    return $pwsh.Source
+  }
+
+  $powershell = Get-Command powershell.exe -ErrorAction SilentlyContinue
+  if ($powershell) {
+    return $powershell.Source
+  }
+
+  throw 'Could not find pwsh or powershell.exe on PATH.'
+}
+
+function Invoke-PowerShellScript {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  $powerShell = Get-PowerShellExecutable
+  $args = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $ScriptPath) + $ArgumentList
+  Invoke-LoggedCommand -FilePath $powerShell -ArgumentList $args
+}
+
+function Get-GitStatusShort {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Resolve-RepoRoot)
+  )
+
+  Invoke-InRepo -RepoRoot $RepoRoot -ScriptBlock {
+    $output = & git status --short
+    $exitCode = if ($LASTEXITCODE -is [int]) { [int]$LASTEXITCODE } else { 0 }
+    if ($exitCode -ne 0) {
+      throw (New-CommandFailedException -Message "git status --short failed with exit code $exitCode" -ExitCode $exitCode)
+    }
+    return @($output)
+  }
+}
+
+function Assert-CleanTrackedState {
+  [CmdletBinding()]
+  param(
+    [string]$RepoRoot = (Resolve-RepoRoot)
+  )
+
+  $status = @(Get-GitStatusShort -RepoRoot $RepoRoot)
+  if ($status.Count -gt 0) {
+    throw "Working tree is not clean:`n$($status -join [Environment]::NewLine)"
+  }
+}
+
+function Assert-RepoRelativePath {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RelativePath
+  )
+
+  $rootFull = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar
+  )
+  $candidate = [System.IO.Path]::GetFullPath((Join-Path $rootFull $RelativePath))
+  $comparison = [System.StringComparison]::OrdinalIgnoreCase
+  $prefix = $rootFull + [System.IO.Path]::DirectorySeparatorChar
+
+  if (($candidate -ne $rootFull) -and (-not $candidate.StartsWith($prefix, $comparison))) {
+    throw "Path '$RelativePath' resolves outside the repo root."
+  }
+
+  return $candidate
+}
+
+function Get-ErrorExitCode {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Management.Automation.ErrorRecord]$ErrorRecord
+  )
+
+  $exception = $ErrorRecord.Exception
+  while ($exception) {
+    if ($exception.Data.Contains('ExitCode')) {
+      return [int]$exception.Data['ExitCode']
+    }
+    $exception = $exception.InnerException
+  }
+
+  if ($global:InterPollLastCommandExitCode -ne 0) {
+    return [int]$global:InterPollLastCommandExitCode
+  }
+
+  return 1
+}
+
+function Get-ErrorCommandLine {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Management.Automation.ErrorRecord]$ErrorRecord
+  )
+
+  $exception = $ErrorRecord.Exception
+  while ($exception) {
+    if ($exception.Data.Contains('CommandLine')) {
+      return [string]$exception.Data['CommandLine']
+    }
+    $exception = $exception.InnerException
+  }
+
+  return ''
+}
+
+function Exit-WithError {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Management.Automation.ErrorRecord]$ErrorRecord,
+
+    [Parameter(Mandatory = $true)]
+    [string]$FailureSummary,
+
+    [switch]$PauseOnFailure
+  )
+
+  $exitCode = Get-ErrorExitCode -ErrorRecord $ErrorRecord
+  $commandLine = Get-ErrorCommandLine -ErrorRecord $ErrorRecord
+
+  [Console]::Error.WriteLine('')
+  [Console]::Error.WriteLine("FAILED: $FailureSummary")
+  if ($commandLine) {
+    [Console]::Error.WriteLine("Command: $commandLine")
+  } else {
+    [Console]::Error.WriteLine("Reason: $($ErrorRecord.Exception.Message)")
+  }
+  [Console]::Error.WriteLine("Exit code: $exitCode")
+
+  if ($PauseOnFailure) {
+    [Console]::Error.WriteLine('')
+    [Console]::Error.Write('Press Enter to exit...')
+    [Console]::ReadLine() | Out-Null
+  }
+
+  exit $exitCode
+}

--- a/tools/windows/secret-scan.ps1
+++ b/tools/windows/secret-scan.ps1
@@ -1,0 +1,222 @@
+# Scan tracked text files for high-confidence hard-coded secrets.
+
+[CmdletBinding()]
+param(
+  [switch]$FailOnFinding,
+  [switch]$IncludeDocs,
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+$secretRules = @(
+  @{
+    Name = 'Private key block'
+    Pattern = '-----BEGIN\s+(?:RSA|DSA|EC|OPENSSH|PGP)?\s*PRIVATE\s+KEY-----'
+  },
+  @{
+    Name = 'Generic assignment secret'
+    Pattern = '(?i)\b(?:api[_-]?key|secret|token|password|passwd|pwd|client[_-]?secret|private[_-]?key)\b\s*[:=]\s*["'']([A-Za-z0-9_\-./+=]{24,})["'']'
+  },
+  @{
+    Name = 'Bearer token'
+    Pattern = '(?i)\bBearer\s+([A-Za-z0-9_\-./+=]{24,})'
+  },
+  @{
+    Name = 'Google API key'
+    Pattern = 'AIza[0-9A-Za-z_\-]{35}'
+  },
+  @{
+    Name = 'GitHub token'
+    Pattern = 'gh[opsu]_[A-Za-z0-9_]{36,}'
+  },
+  @{
+    Name = 'Slack token'
+    Pattern = 'xox[baprs]-[A-Za-z0-9-]{20,}'
+  },
+  @{
+    Name = 'AWS access key'
+    Pattern = 'AKIA[0-9A-Z]{16}'
+  },
+  @{
+    Name = 'Possible JWT'
+    Pattern = 'eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}'
+  }
+)
+
+$skipPathPatterns = @(
+  '(^|/)node_modules/',
+  '(^|/)dist/',
+  '(^|/)dist-ssr/',
+  '(^|/)build/',
+  '(^|/)coverage/',
+  '(^|/)\.cache/',
+  '(^|/)peer-data/',
+  '(^|/)radata/',
+  '(^|/)app/gun-relay-server/radata/',
+  '(^|/)gun-relay-server/radata/',
+  '(^|/)relay-server/data/',
+  '(^|/)message-cache\.json$',
+  '(^|/)storage\.txt$',
+  '(^|/)package-lock\.json$',
+  '(^|/)app\.zip$',
+  '(^|/)shared-validation\.zip$'
+)
+
+$binaryExtensions = @(
+  '.zip', '.7z', '.gz', '.tar', '.tgz', '.png', '.jpg', '.jpeg', '.gif',
+  '.webp', '.ico', '.svgz', '.pdf', '.woff', '.woff2', '.ttf', '.eot',
+  '.mp4', '.webm', '.mov', '.mp3', '.wav', '.wasm'
+)
+
+$docExtensions = @('.md', '.markdown', '.txt')
+
+function ConvertTo-RepoSlashPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  return ($Path -replace '\\', '/')
+}
+
+function Test-ScannablePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $slashPath = ConvertTo-RepoSlashPath -Path $Path
+
+  foreach ($pattern in $skipPathPatterns) {
+    if ($slashPath -match $pattern) {
+      return $false
+    }
+  }
+
+  $extension = [System.IO.Path]::GetExtension($Path).ToLowerInvariant()
+  if ($binaryExtensions -contains $extension) {
+    return $false
+  }
+
+  if (-not $IncludeDocs -and (($docExtensions -contains $extension) -or $slashPath -match '(^|/)docs/')) {
+    return $false
+  }
+
+  return $true
+}
+
+function Redact-SecretText {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value
+  )
+
+  if ($Value.Length -le 8) {
+    return '<redacted>'
+  }
+
+  $prefixLength = [Math]::Min(4, $Value.Length)
+  $suffixLength = [Math]::Min(4, [Math]::Max(0, $Value.Length - $prefixLength))
+  return $Value.Substring(0, $prefixLength) + '...' + $Value.Substring($Value.Length - $suffixLength)
+}
+
+function Get-RedactedLine {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Line,
+
+    [Parameter(Mandatory = $true)]
+    [System.Text.RegularExpressions.Match]$Match
+  )
+
+  $secret = if ($Match.Groups.Count -gt 1 -and $Match.Groups[1].Success) {
+    $Match.Groups[1].Value
+  } else {
+    $Match.Value
+  }
+
+  return $Line.Replace($secret, (Redact-SecretText -Value $secret)).Trim()
+}
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Write-Host 'Scanning tracked files only (git ls-files). Untracked files are not included.'
+
+  $findings = New-Object System.Collections.Generic.List[object]
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Assert-CommandAvailable -Name 'git' | Out-Null
+
+    $rawFiles = & git -c core.quotepath=false ls-files -z
+    $exitCode = if ($LASTEXITCODE -is [int]) { [int]$LASTEXITCODE } else { 0 }
+    if ($exitCode -ne 0) {
+      throw (New-CommandFailedException -Message "git ls-files failed with exit code $exitCode" -ExitCode $exitCode)
+    }
+
+    $files = @($rawFiles -split "`0" | Where-Object { $_ })
+    foreach ($file in $files) {
+      if (-not (Test-ScannablePath -Path $file)) {
+        continue
+      }
+
+      $absolutePath = Assert-RepoRelativePath -RepoRoot $repoRoot -RelativePath $file
+      if (-not (Test-Path -LiteralPath $absolutePath -PathType Leaf)) {
+        continue
+      }
+
+      try {
+        $content = Get-Content -LiteralPath $absolutePath -Raw -ErrorAction Stop
+      } catch {
+        continue
+      }
+
+      if ($null -eq $content) {
+        $content = ''
+      }
+
+      if ($content.IndexOf([char]0) -ge 0) {
+        continue
+      }
+
+      $lines = $content -split "`r?`n"
+      for ($lineNumber = 0; $lineNumber -lt $lines.Count; $lineNumber++) {
+        $line = $lines[$lineNumber]
+        foreach ($rule in $secretRules) {
+          $matches = [regex]::Matches($line, [string]$rule.Pattern)
+          foreach ($match in $matches) {
+            $findings.Add([pscustomobject]@{
+              Path = $file
+              Line = $lineNumber + 1
+              Rule = [string]$rule.Name
+              Preview = Get-RedactedLine -Line $line -Match $match
+            }) | Out-Null
+          }
+        }
+      }
+    }
+  }
+
+  if ($findings.Count -eq 0) {
+    Write-Host 'No high-confidence hard-coded secrets found in tracked text files.'
+    exit 0
+  }
+
+  [Console]::Error.WriteLine("Potential hard-coded secrets found: $($findings.Count)")
+  foreach ($finding in $findings) {
+    [Console]::Error.WriteLine("- $($finding.Path):$($finding.Line) [$($finding.Rule)] $($finding.Preview)")
+  }
+
+  if ($FailOnFinding) {
+    throw (New-CommandFailedException -Message "Secret scan found $($findings.Count) potential secret(s)." -ExitCode 1)
+  }
+
+  Write-Host ''
+  Write-Host 'Secret scan is report-only by default. Re-run with -FailOnFinding to make findings blocking.'
+  exit 0
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Secret scan failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/security-audit.ps1
+++ b/tools/windows/security-audit.ps1
@@ -1,0 +1,37 @@
+# Run npm dependency audit as a fail-closed security gate.
+
+[CmdletBinding()]
+param(
+  [ValidateSet('moderate', 'high', 'critical')]
+  [string]$AuditLevel = 'high',
+
+  [switch]$ProductionOnly,
+  [switch]$Json,
+
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    $npm = Get-NpmCommand
+
+    $args = @('audit', "--audit-level=$AuditLevel")
+    if ($ProductionOnly) {
+      $args += '--omit=dev'
+    }
+    if ($Json) {
+      $args += '--json'
+    }
+
+    Invoke-LoggedCommand -FilePath $npm -ArgumentList $args
+  }
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Security audit failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/security-smoke.ps1
+++ b/tools/windows/security-smoke.ps1
@@ -1,0 +1,125 @@
+# Run safe local security smoke checks and summarize all results.
+
+[CmdletBinding()]
+param(
+  [ValidateSet('moderate', 'high', 'critical')]
+  [string]$AuditLevel = 'high',
+
+  [switch]$ProductionOnly,
+  [switch]$SkipAudit,
+  [switch]$SkipAdversarialTests,
+  [switch]$SkipSecretScan,
+  [switch]$FailOnSecretFinding,
+  [switch]$AllowNoChecks,
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+function Invoke-SmokeCheck {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  Write-Host "== $Name =="
+  try {
+    Invoke-PowerShellScript -ScriptPath $ScriptPath -ArgumentList $ArgumentList | ForEach-Object {
+      Write-Host $_
+    }
+    return [pscustomobject]@{
+      Name = $Name
+      ExitCode = 0
+      Status = 'PASS'
+    }
+  } catch {
+    $exitCode = Get-ErrorExitCode -ErrorRecord $_
+    $commandLine = Get-ErrorCommandLine -ErrorRecord $_
+    [Console]::Error.WriteLine('')
+    [Console]::Error.WriteLine("FAILED: $Name failed.")
+    if ($commandLine) {
+      [Console]::Error.WriteLine("Command: $commandLine")
+    } else {
+      [Console]::Error.WriteLine("Reason: $($_.Exception.Message)")
+    }
+    [Console]::Error.WriteLine("Exit code: $exitCode")
+    [Console]::Error.WriteLine('')
+
+    return [pscustomobject]@{
+      Name = $Name
+      ExitCode = $exitCode
+      Status = 'FAIL'
+    }
+  }
+}
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    Get-NpmCommand | Out-Null
+  }
+
+  $results = @()
+
+  if ($SkipAdversarialTests) {
+    Write-Host '== Adversarial tests skipped =='
+  } else {
+    $results += Invoke-SmokeCheck -Name 'Adversarial tests' -ScriptPath (Join-Path $PSScriptRoot 'adversarial-test.ps1')
+  }
+
+  if ($SkipSecretScan) {
+    Write-Host '== Secret scan skipped =='
+  } else {
+    $secretScanArgs = @()
+    if ($FailOnSecretFinding) {
+      $secretScanArgs += '-FailOnFinding'
+    }
+    $results += Invoke-SmokeCheck -Name 'Secret scan' -ScriptPath (Join-Path $PSScriptRoot 'secret-scan.ps1') -ArgumentList $secretScanArgs
+  }
+
+  if ($SkipAudit) {
+    Write-Host '== Security audit skipped =='
+  } else {
+    $auditArgs = @('-AuditLevel', $AuditLevel)
+    if ($ProductionOnly) {
+      $auditArgs += '-ProductionOnly'
+    }
+    $results += Invoke-SmokeCheck -Name 'Dependency audit' -ScriptPath (Join-Path $PSScriptRoot 'security-audit.ps1') -ArgumentList $auditArgs
+  }
+
+  Write-Host ''
+  Write-Host '== Security smoke summary =='
+  if ($results.Count -eq 0) {
+    Write-Host 'No checks were run.'
+    if ($AllowNoChecks) {
+      Write-Host 'No-op security smoke run allowed because -AllowNoChecks was provided.'
+      exit 0
+    }
+
+    throw (New-CommandFailedException -Message 'Security smoke refused to pass because no checks were run. Re-run with -AllowNoChecks for an intentional no-op.' -ExitCode 1)
+  }
+
+  foreach ($result in $results) {
+    Write-Host ("{0}: {1} (exit {2})" -f $result.Name, $result.Status, $result.ExitCode)
+  }
+
+  $failed = @($results | Where-Object { $_.ExitCode -ne 0 })
+  if ($failed.Count -gt 0) {
+    $firstExitCode = [int]$failed[0].ExitCode
+    throw (New-CommandFailedException -Message "Security smoke failed. First failing check: $($failed[0].Name)." -ExitCode $firstExitCode)
+  }
+
+  exit 0
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Security smoke failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/setup.ps1
+++ b/tools/windows/setup.ps1
@@ -1,0 +1,33 @@
+# Verify prerequisites and install local npm dependencies for Windows contributors.
+
+[CmdletBinding()]
+param(
+  [switch]$SkipInstall,
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    Assert-CommandAvailable -Name 'node' | Out-Null
+    $npm = Get-NpmCommand
+
+    Invoke-LoggedCommand -FilePath 'node' -ArgumentList @('-v')
+    Invoke-LoggedCommand -FilePath $npm -ArgumentList @('-v')
+
+    if ($SkipInstall) {
+      Write-Host 'Skipping npm ci because -SkipInstall was provided.'
+      return
+    }
+
+    Invoke-LoggedCommand -FilePath $npm -ArgumentList @('ci')
+  }
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Windows setup failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/test.ps1
+++ b/tools/windows/test.ps1
@@ -1,0 +1,35 @@
+# Run the Vitest unit test workflow on Windows.
+
+[CmdletBinding()]
+param(
+  [string[]]$TestFilter = @(),
+  [switch]$Watch,
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    $npm = Get-NpmCommand
+    Assert-NodeModulesInstalled -RepoRoot $repoRoot
+    Assert-LocalNpmBin -Name 'vitest' -RepoRoot $repoRoot | Out-Null
+
+    $scriptName = if ($Watch) { 'test:watch' } else { 'test' }
+    $args = @('run', $scriptName)
+
+    if ($TestFilter.Count -gt 0) {
+      $args += '--'
+      $args += $TestFilter
+    }
+
+    Invoke-LoggedCommand -FilePath $npm -ArgumentList $args
+  }
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Tests failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/typecheck.ps1
+++ b/tools/windows/typecheck.ps1
@@ -1,0 +1,25 @@
+# Run the reproducible TypeScript/Vue typecheck gate.
+
+[CmdletBinding()]
+param(
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    $npm = Get-NpmCommand
+    Assert-NodeModulesInstalled -RepoRoot $repoRoot
+    Assert-LocalNpmBin -Name 'vue-tsc' -RepoRoot $repoRoot | Out-Null
+
+    Invoke-LoggedCommand -FilePath $npm -ArgumentList @('exec', '--', 'vue-tsc', '--noEmit', '-p', 'tsconfig.json')
+  }
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Typecheck failed.' -PauseOnFailure:$PauseOnFailure
+}

--- a/tools/windows/validate.ps1
+++ b/tools/windows/validate.ps1
@@ -1,0 +1,52 @@
+# Run the Windows PR validation workflow.
+
+[CmdletBinding()]
+param(
+  [switch]$SkipBuild,
+  [switch]$SkipAudit,
+  [string[]]$TestFilter = @(),
+  [switch]$PauseOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\common.ps1"
+
+try {
+  $repoRoot = Resolve-RepoRoot
+
+  Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+    Get-PackageManager -RepoRoot $repoRoot | Out-Null
+    Get-NpmCommand | Out-Null
+  }
+
+  Write-Host '== Typecheck =='
+  Invoke-PowerShellScript -ScriptPath (Join-Path $PSScriptRoot 'typecheck.ps1')
+
+  Write-Host '== Tests =='
+  $testArgs = @()
+  if ($TestFilter.Count -gt 0) {
+    $testArgs += '-TestFilter'
+    $testArgs += $TestFilter
+  }
+  Invoke-PowerShellScript -ScriptPath (Join-Path $PSScriptRoot 'test.ps1') -ArgumentList $testArgs
+
+  if ($SkipAudit) {
+    Write-Host '== Security audit skipped =='
+  } else {
+    Write-Host '== Security audit =='
+    Invoke-PowerShellScript -ScriptPath (Join-Path $PSScriptRoot 'security-audit.ps1')
+  }
+
+  if ($SkipBuild) {
+    Write-Host '== Build skipped =='
+  } else {
+    Write-Host '== Build =='
+    Invoke-InRepo -RepoRoot $repoRoot -ScriptBlock {
+      $npm = Get-NpmCommand
+      Invoke-LoggedCommand -FilePath $npm -ArgumentList @('run', 'build')
+    }
+  }
+} catch {
+  Exit-WithError -ErrorRecord $_ -FailureSummary 'Windows validation failed.' -PauseOnFailure:$PauseOnFailure
+}


### PR DESCRIPTION
## Summary

Adds Windows PowerShell tooling for setup, test, typecheck, dependency audit, validation, adversarial security tests, secret scanning, and security smoke checks.

## Added scripts

- `tools/windows/common.ps1`
- `tools/windows/setup.ps1`
- `tools/windows/test.ps1`
- `tools/windows/typecheck.ps1`
- `tools/windows/security-audit.ps1`
- `tools/windows/validate.ps1`
- `tools/windows/adversarial-test.ps1`
- `tools/windows/secret-scan.ps1`
- `tools/windows/security-smoke.ps1`

Also adds:

- `docs/windows_tooling.md`

## Current expected repo state

- `setup.ps1` passes
- `test.ps1` passes
- `adversarial-test.ps1` passes
- `secret-scan.ps1` passes
- `typecheck.ps1` fails on existing Vue/TypeScript errors
- `security-audit.ps1` fails on existing npm advisories
- `validate.ps1` fails closed at typecheck
- `security-smoke.ps1` fails only because npm audit currently fails
- `security-smoke.ps1 -SkipAudit` passes

## Validation

- PowerShell parse check for `tools/windows/*.ps1`: passed
- `.\tools\windows\setup.ps1 -SkipInstall`: passed
- `.\tools\windows\test.ps1`: passed
- `.\tools\windows\adversarial-test.ps1`: passed
- `.\tools\windows\secret-scan.ps1`: passed
- `.\tools\windows\security-smoke.ps1 -SkipAudit`: passed
- `.\tools\windows\typecheck.ps1`: fails as expected on existing typecheck errors
- `.\tools\windows\security-audit.ps1`: fails as expected on existing npm audit findings