### PR TITLE
docs: add user key identity model notes

### DIFF
--- a/docs/user-key-identity-map.md
+++ b/docs/user-key-identity-map.md
@@ -1,0 +1,101 @@
+# User Key / Identity Architecture Map
+
+Read-only architecture note for the first user/key identity pass.
+
+## Goal
+
+Define a small identity model before changing runtime code:
+
+- public key = durable identity
+- username = readable alias
+- private key stays local only
+- profile records should be signed by the user key
+- multi-device support comes later
+- encrypted community keys stay separate from identity keys
+
+## Existing relevant files
+
+### src/services/keyService.ts
+
+Handles Schnorr keypair generation / import / export.
+
+This appears to be the closest existing service for identity/signing keys.
+
+Relevant role:
+
+- generate keypair
+- import/export keypair
+- provide signing/verification primitives or key material for other services
+
+### src/services/userService.ts
+
+Contains UserProfile, UserStats, and user/profile CRUD/search logic.
+
+Likely place where readable profile data belongs:
+
+- username
+- display name
+- avatar
+- stats
+- public profile metadata
+
+Open question: whether UserService should become identity-authoritative, or only manage display/profile records.
+
+### src/services/keyVaultService.ts
+
+Manages stored encryption keys.
+
+This should probably remain focused on encryption/community access keys, not identity/auth keys.
+
+Important separation:
+
+- identity key = signs user/profile/actions
+- encryption key = unlocks private community/content
+
+### src/services/encryptionService.ts
+
+Provides AES/HMAC primitives.
+
+Useful for private communities and encrypted content, but should not be mixed with identity semantics directly.
+
+### src/services/communityService.ts
+
+Handles community creation, joining, signing/verifying, private community metadata, and key-related flows.
+
+This is important for future encrypted communities, but should not be touched in the first identity PR.
+
+### src/components/KeyManagementSection.vue
+
+UI for key import/export/delete flows.
+
+Should not be changed in the first docs-only PR.
+
+### Stores
+
+Relevant stores include:
+
+- src/stores/communityStore.ts
+- src/stores/postStore.ts
+- src/stores/pollStore.ts
+- src/stores/commentStore.ts
+
+They contain local/session tracking and hooks into private community/content flows.
+
+These should not be changed in the first identity PR.
+
+## Proposed v1 identity model
+
+For the first version:
+
+- identity is the user public key
+- username is a human-readable alias
+- profile record is signed by the identity key
+- private key never leaves local device storage
+- if two users choose the same username, UI can show a short public-key fingerprint
+- global unique usernames are out of scope
+
+Example display:
+
+```text
+pavlo#A91F
+```

--- a/docs/user-key-identity-pr-checklist.md
+++ b/docs/user-key-identity-pr-checklist.md
@@ -1,0 +1,84 @@
+# User Key / Identity PR Checklist
+
+Scope for branch: pavlo-user-keys-v1
+
+## Goal
+
+Create a minimal, safe foundation for InterPoll user identity:
+
+- public key = real identity
+- username = readable alias
+- private key stays local only
+- profile/user record should be signed by the user key
+- multi-device support comes later
+- encrypted communities stay separate from identity keys
+
+## Current state
+
+Existing relevant files:
+
+- src/services/keyService.ts
+ - existing keypair generation / import / export logic
+- src/services/userService.ts
+ - current user/profile CRUD and search
+- src/services/keyVaultService.ts
+ - encryption key storage / import / export
+- src/services/encryptionService.ts
+ - AES/HMAC primitives
+- src/services/communityService.ts
+ - community signing/verifying and private community key logic
+
+## Recommended first PR
+
+Start with documentation only:
+
+- add docs/user-key-identity-map.md
+- add this checklist
+- do not change runtime behavior yet
+
+This gives the team a clear model to review before code changes.
+
+## Optional second PR
+
+If the team agrees, add a tiny identity helper:
+
+- src/services/userIdentityService.ts
+
+Possible responsibilities:
+
+- create signed profile record
+- verify signed profile record
+- treat public key as identity
+- treat username as alias
+- never store private key outside local device storage
+
+## Do not touch in this PR
+
+- relay-server.js
+- OAuth/session logic
+- GunDB sync logic
+- private community encryption flow
+- invite link logic
+- UI components
+- multi-device approval
+- global username registry
+
+## Open questions for maintainers
+
+1. Should profile signing reuse existing KeyService directly?
+2. Is current UserService intended to be identity-authoritative, or only profile/display data?
+3. Should username uniqueness be local/UI-only for v1?
+4. Should signed profiles be stored in GunDB as public profile records?
+5. Should public key fingerprints be displayed when usernames collide?
+6. Should encrypted community keys stay fully separate from identity keys?
+
+## Suggested v1 identity language
+
+For v1:
+
+- identity is the public key
+- username is an alias
+- private key stays local
+- profile records are signed
+- global unique usernames are out of scope
+- multi-device identity recovery is out of scope


### PR DESCRIPTION
Adds a small docs-only note for the proposed v1 user/key identity model.

No runtime code changes.

Summary:
- public key = durable identity
- username = readable alias
- private key stays local only
- signed profile records
- multi-device and encrypted communities are left for later
- identity keys stay separate from community encryption keys