### PR TITLE
fix/ws peer count auth gate

### DIFF
--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -41,7 +41,12 @@ export class WebSocketService {
   private static peers: Set<string> = new Set();
   private static peerAddresses: Map<string, { peerId: string; relayUrl: string; gunPeers: string[]; joinedAt: number }> = new Map();
   private static readonly MAX_PEER_ADDRESSES = 200;
-  private static statusListeners: Set<(status: { connected: boolean; peerCount: number }) => void> = new Set();
+  // True when the relay rejected our `register` for lack of an authenticated
+  // session. In that state we hold an open socket but are NOT in the relay's
+  // client registry, so we never receive `peer-list` and can never see peers —
+  // the UI needs to know this to explain the perpetual "0 peers".
+  private static registrationRejected = false;
+  private static statusListeners: Set<(status: { connected: boolean; peerCount: number; registrationRejected: boolean }) => void> = new Set();
   private static knownServers: Map<string, KnownServer> = new Map();
   private static readonly MAX_KNOWN_SERVERS = 50;
   private static readonly DISCOVERY_TTL_MS = 5 * 60_000;
@@ -101,6 +106,9 @@ export class WebSocketService {
         if (epoch !== this.connectionEpoch || socket !== this.ws) return;
         this.isConnected = true;
         this.reconnectAttempts = 0;
+        // Optimistically assume registration will succeed; the relay tells us
+        // otherwise via an AUTH_REQUIRED error handled in onmessage.
+        this.registrationRejected = false;
 
         this.peers.add(this.peerId);
         this.notifyStatus();
@@ -153,6 +161,19 @@ export class WebSocketService {
             this.sendToRelay('register', { peerId: this.peerId });
             this.sendToRelay('join-room', { roomId: 'default' });
             this.broadcastAddresses();
+            return;
+          }
+
+          // The relay gates registration (and therefore peer-list, broadcast and
+          // room membership) behind an authenticated session. Without one we stay
+          // connected but invisible to the peer registry — surface it once so the
+          // UI can explain "0 peers" instead of silently misreporting the network.
+          if (message.type === 'error' && message.code === 'AUTH_REQUIRED') {
+            if (!this.registrationRejected) {
+              console.warn('[WS] Relay registration requires an authenticated session — sign in to join the peer network. Gun-layer sync is unaffected.');
+            }
+            this.registrationRejected = true;
+            this.notifyStatus();
             return;
           }
 
@@ -237,6 +258,7 @@ export class WebSocketService {
         this.isConnected = false;
         this.peers.clear();
         this.peerAddresses.clear();
+        this.registrationRejected = false;
         this.stopKeepAlive();
         this.notifyStatus();
 
@@ -676,9 +698,14 @@ export class WebSocketService {
     return Array.from(this.peers).filter((id) => id && id !== this.peerId);
   }
 
-  static onStatusChange(callback: (status: { connected: boolean; peerCount: number }) => void): () => void {
+  /** True when the relay rejected registration for lack of an authenticated session. */
+  static isRegistrationRejected(): boolean {
+    return this.registrationRejected;
+  }
+
+  static onStatusChange(callback: (status: { connected: boolean; peerCount: number; registrationRejected: boolean }) => void): () => void {
     this.statusListeners.add(callback);
-    callback({ connected: this.isConnected, peerCount: this.getPeerCount() });
+    callback({ connected: this.isConnected, peerCount: this.getPeerCount(), registrationRejected: this.registrationRejected });
 
     return () => {
       this.statusListeners.delete(callback);
@@ -730,7 +757,11 @@ export class WebSocketService {
   }
 
   private static notifyStatus() {
-    const snapshot = { connected: this.isConnected, peerCount: this.getPeerCount() };
+    const snapshot = {
+      connected: this.isConnected,
+      peerCount: this.getPeerCount(),
+      registrationRejected: this.registrationRejected,
+    };
     this.statusListeners.forEach((listener) => {
       try {
         listener(snapshot);

--- a/src/views/ResiliencePage.vue
+++ b/src/views/ResiliencePage.vue
@@ -68,9 +68,22 @@
           <div class="status-bar mb-3">
             <div class="status-bar-item">
               <span class="status-dot" :class="wsConnected ? 'online' : 'offline'"></span>
-              <span class="text-sm">{{ peerCount }} peer{{ peerCount !== 1 ? 's' : '' }}</span>
+              <span class="text-sm">{{ peerCount }} relay peer{{ peerCount !== 1 ? 's' : '' }}</span>
+            </div>
+            <div class="status-bar-item">
+              <span class="status-dot" :class="gunConnectedCount > 0 ? 'online' : 'offline'"></span>
+              <span class="text-sm">{{ gunConnectedCount }} sync peer{{ gunConnectedCount !== 1 ? 's' : '' }}</span>
             </div>
             <span v-if="lastScanAt" class="text-xs opacity-50">Last scan: {{ lastScanAt }}</span>
+          </div>
+
+          <!-- Registration gated behind auth: explain the perpetual 0 relay peers -->
+          <div v-if="wsRegistrationRejected" class="mt-1 mb-3 p-2 rounded-lg text-xs glass-inset flex items-center gap-2">
+            <ion-icon :icon="lockClosedOutline" color="warning" />
+            <span class="opacity-80">
+              Connected to the relay, but joining its peer list requires signing in.
+              You're still syncing over {{ gunConnectedCount }} Gun peer{{ gunConnectedCount !== 1 ? 's' : '' }} — sign in to also appear in the relay peer network.
+            </span>
           </div>
 
           <ion-button expand="block" :disabled="scanning" @click="scanAllRelays">
@@ -731,6 +744,7 @@ const relays = ref<RelayEndpoint[]>([]);
 const activeRelay = ref<RelayEndpoint | null>(null);
 const wsConnected = ref(false);
 const peerCount = ref(0);
+const wsRegistrationRejected = ref(false);
 const isTor = ref(false);
 
 const scanning = ref(false);
@@ -1020,6 +1034,7 @@ function refreshStatus() {
   activeRelay.value = RelayManager.getActiveRelay();
   wsConnected.value = WebSocketService.getConnectionStatus();
   peerCount.value = WebSocketService.getPeerCount();
+  wsRegistrationRejected.value = WebSocketService.isRegistrationRejected();
   isTor.value = RelayHealthService.isTorBrowser();
 }
 
@@ -1263,6 +1278,7 @@ onMounted(async () => {
   cleanups.push(WebSocketService.onStatusChange((status) => {
     wsConnected.value = status.connected;
     peerCount.value = status.peerCount;
+    wsRegistrationRejected.value = status.registrationRejected;
     refreshResilience();
   }));
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -617,7 +617,11 @@
           <div class="metrics-grid">
             <div class="metric-card">
               <div class="metric-value">{{ networkStatus.peerCount }}</div>
-              <div class="metric-label">Active Peers</div>
+              <div class="metric-label">Relay Peers</div>
+            </div>
+            <div class="metric-card">
+              <div class="metric-value">{{ networkStatus.gunConnectedCount }}</div>
+              <div class="metric-label">Sync Peers</div>
             </div>
             <div class="metric-card">
               <div class="metric-value">
@@ -639,6 +643,13 @@
               </div>
               <div class="metric-label">Chain Status</div>
             </div>
+          </div>
+          <div v-if="networkStatus.registrationRejected" class="reg-gate-hint">
+            <ion-icon :icon="lockClosedOutline"></ion-icon>
+            <span>
+              Connected to the relay, but joining its peer list requires signing in.
+              You're still syncing over {{ networkStatus.gunConnectedCount }} Gun peer{{ networkStatus.gunConnectedCount !== 1 ? 's' : '' }} — sign in to also appear in the relay peer network.
+            </span>
           </div>
           <div class="separator"></div>
         </div>
@@ -1412,6 +1423,26 @@
 }
 
 /* Network Status */
+.reg-gate-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255, 193, 7, 0.06);
+  border: 1px solid rgba(255, 193, 7, 0.18);
+  font-size: 12px;
+  line-height: 1.45;
+  opacity: 0.85;
+}
+
+.reg-gate-hint ion-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--ion-color-warning);
+}
+
 .status-header {
   display: flex;
   justify-content: space-between;
@@ -1914,7 +1945,8 @@ import {
   eyeOutline,
   closeCircleOutline,
   checkmarkCircleOutline,
-  addOutline
+  addOutline,
+  lockClosedOutline
 } from 'ionicons/icons';
 import { PinningService } from '../services/pinningService';
 import { StorageManager } from '../services/storageManager';
@@ -2280,6 +2312,7 @@ const networkStatus = ref({
   connectedWsUrl: '',
   gunConnected: false,
   peerCount: 0,
+  registrationRejected: false,
   gunPeerCount: 0,
   gunConnectedCount: 0,
   gunAvgLatencyMs: undefined as number | undefined,
@@ -2809,6 +2842,7 @@ function refreshNetwork() {
     connectedWsUrl,
     gunConnected: gunStats.isConnected,
     peerCount: WebSocketService.getPeerCount(),
+    registrationRejected: WebSocketService.isRegistrationRejected(),
     gunPeerCount: gunStats.peerCount,
     gunConnectedCount: gunStats.connectedCount,
     gunAvgLatencyMs: gunStats.avgLatencyMs,


### PR DESCRIPTION
- **fix: explain empty relay peer list and count Gun sync peers in Network Status**
- **fix: mirror relay/sync peer split and auth-gate hint in Settings Network tab**
